### PR TITLE
Umstellung auf 'includeCurrentPageSubPath'

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -20,4 +20,4 @@ pages:
 requires:
     packages:
         media_manager: '^2.0.0'
-    redaxo: ^5.0
+    redaxo: ^5.1

--- a/pages/index.php
+++ b/pages/index.php
@@ -7,4 +7,4 @@
  * @var rex_addon $this
  */
 
-require rex_be_controller::getCurrentPageObject()->getSubPath();
+rex_be_controller::includeCurrentPageSubPath();

--- a/plugins/imageoptimizer/package.yml
+++ b/plugins/imageoptimizer/package.yml
@@ -11,4 +11,4 @@ page:
         mode: { title: 'translate:imageoptimizer_modesetting', hidden: false}
         settings: { title: 'translate:imageoptimizer_advanced_settings', hidden: false}
 requires:
-    redaxo: ^5.0
+    redaxo: ^5.1

--- a/plugins/imageoptimizer/pages/index.php
+++ b/plugins/imageoptimizer/pages/index.php
@@ -10,4 +10,4 @@ echo rex_view::title($this->i18n('title')); // $this->i18n('title') ist eine Kur
 
 // Subpages können über diese Methode eingebunden werden. So ist sichergestellt, dass auch Subpages funktionieren,
 // die von anderen Addons/Plugins hinzugefügt wurden
-include rex_be_controller::getCurrentPageObject()->getSubPath();
+rex_be_controller::includeCurrentPageSubPath();

--- a/plugins/upload_precompressor/package.yml
+++ b/plugins/upload_precompressor/package.yml
@@ -17,4 +17,4 @@ page:
 
 
 requires:
-    redaxo: ^5.0
+    redaxo: ^5.1

--- a/plugins/upload_precompressor/pages/index.php
+++ b/plugins/upload_precompressor/pages/index.php
@@ -10,4 +10,4 @@ echo rex_view::title($this->i18n('title')); // $this->i18n('title') ist eine Kur
 
 // Subpages können über diese Methode eingebunden werden. So ist sichergestellt, dass auch Subpages funktionieren,
 // die von anderen Addons/Plugins hinzugefügt wurden
-include rex_be_controller::getCurrentPageObject()->getSubPath();
+rex_be_controller::includeCurrentPageSubPath();


### PR DESCRIPTION
Ziel des PR: Umstellung auf aktuelle rex-Methoden und einheitliche Vorgehensweise
in möglichst allen AddOns.

Wie ich letztens gelernt habe, gibt es eine alte und eine aktuelle Methode, die 
Sub-Pages einzubinden. Die neue Methode ist seit REDAXO 5.1 verfügbar. 

Die alte Methode funktioniert weiterhin, sollte aber wegen verbesserter Interoperabilität
zwischen AddOns auf die neue Version umgestellt werden (Hinweis von gharlan).
In den Core-Addons ist das bereits geschehen, desgleichen bei einige FOR- und Y-Addons.
Bezogen auf das Addon selbst sind beide Varianten derzeit gleichwertig. Die neue Methode
erlaubt z.B. eine verbesserte Einbindung von Pages aus anderen Addons, die dann im 
Context des Quell-Addons laufen und nicht des Ziel-Addons.

Betroffen sind rund 40 AddOns (FOR/Y), konkret deren Script **pages/index.php**, das
wie folgt geändert werden sollte:

Alt:
```
    echo rex_view::title(.....);
    include rex_be_controller::getCurrentPageObject()->getSubPath();
```
ab REDAXO 5.1:
```
    echo rex_view::title(.....);
    rex_be_controller::includeCurrentPageSubPath();
```